### PR TITLE
Client Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ use Okta;
 $okta = new Okta\Client('foo', 'api_key');
 ```
 
+You may also optionally pass an array of config options as the third argument:
+
+```php
+$okta = new Okta\Client('foo', 'api_key', [
+    'bootstrap' => false, // Don't auto-bootstrap the Okta resource properties
+    'preview'   => true,  // Use the okta preview (oktapreview.com) domain
+    'headers'   => [
+        'Some-Header'    => 'Some value',
+        'Another-Header' => 'Another value'
+    ]
+]);
+```
+
 Usage
 -----
 

--- a/docs/classes/Okta.Client.html
+++ b/docs/classes/Okta.Client.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1431898321"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1201344568"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-1431898321" class="accordion-body collapse in">
+            <div id="namespace-1201344568" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-212438487"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1859191485"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-212438487" class="accordion-body collapse ">
+            <div id="namespace-1859191485" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1582882806"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1848643771"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-1582882806" class="accordion-body collapse ">
+            <div id="namespace-1848643771" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -573,7 +573,7 @@
             <article class="method">
                 <h3 class="public ">__construct()</h3>
                 <a href="#source-view" role="button" class="pull-right btn" data-toggle="modal" style="font-size: 1.1em; padding: 9px 14px"><i class="icon-code"></i></a>
-                <pre class="signature" style="margin-right: 54px;">__construct(string  <span class="argument">$org</span>, string  <span class="argument">$key</span>, array  <span class="argument">$headers = array()</span>, boolean  <span class="argument">$bootstrap = true</span>) </pre>
+                <pre class="signature" style="margin-right: 54px;">__construct(string  <span class="argument">$org</span>, string  <span class="argument">$key</span>, array  <span class="argument">$config = array()</span>) </pre>
                 <p><em>Okta\Client constructor method</em></p>
                 
 
@@ -591,13 +591,8 @@
                             </tr>
                                                     <tr>
                                 <td>array</td>
-                                <td>$headers </td>
-                                <td><p>Array of headers in header_name =&gt; value format</p></td>
-                            </tr>
-                                                    <tr>
-                                <td>boolean</td>
-                                <td>$bootstrap </td>
-                                <td><p>If true, bootstrap Okta resource properties</p></td>
+                                <td>$config </td>
+                                <td><p>Array of Client config key/values</p></td>
                             </tr>
                                             </table>
                 
@@ -771,7 +766,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/classes/Okta.Exception.html
+++ b/docs/classes/Okta.Exception.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-650633783"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1390326788"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-650633783" class="accordion-body collapse in">
+            <div id="namespace-1390326788" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1936649083"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-808141223"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1936649083" class="accordion-body collapse ">
+            <div id="namespace-808141223" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-648440564"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1363697084"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-648440564" class="accordion-body collapse ">
+            <div id="namespace-1363697084" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -625,7 +625,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/classes/Okta.Request.html
+++ b/docs/classes/Okta.Request.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-799334594"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-868539365"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-799334594" class="accordion-body collapse in">
+            <div id="namespace-868539365" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-635621563"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-2038076520"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-635621563" class="accordion-body collapse ">
+            <div id="namespace-2038076520" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-126276709"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-572986987"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-126276709" class="accordion-body collapse ">
+            <div id="namespace-572986987" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -1040,7 +1040,7 @@ indefinitely (the default behavior).</em></p>
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/classes/Okta.Resource.App.html
+++ b/docs/classes/Okta.Resource.App.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-2060209994"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-645394068"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-2060209994" class="accordion-body collapse in">
+            <div id="namespace-645394068" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1075456825"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1163268901"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1075456825" class="accordion-body collapse ">
+            <div id="namespace-1163268901" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1791033389"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1215192451"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-1791033389" class="accordion-body collapse ">
+            <div id="namespace-1215192451" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -1307,7 +1307,7 @@ application</em></p>
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/classes/Okta.Resource.Authentication.html
+++ b/docs/classes/Okta.Resource.Authentication.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1844088930"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-941508703"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-1844088930" class="accordion-body collapse in">
+            <div id="namespace-941508703" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-843047129"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-331073819"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-843047129" class="accordion-body collapse ">
+            <div id="namespace-331073819" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1886257965"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1611399138"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-1886257965" class="accordion-body collapse ">
+            <div id="namespace-1611399138" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -1364,7 +1364,7 @@ authentication or recovery transaction</p>
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/classes/Okta.Resource.Base.html
+++ b/docs/classes/Okta.Resource.Base.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-742240351"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1969513380"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-742240351" class="accordion-body collapse in">
+            <div id="namespace-1969513380" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1453492731"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-581307574"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1453492731" class="accordion-body collapse ">
+            <div id="namespace-581307574" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1034292027"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-152729395"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-1034292027" class="accordion-body collapse ">
+            <div id="namespace-152729395" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -419,7 +419,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/classes/Okta.Resource.Event.html
+++ b/docs/classes/Okta.Resource.Event.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1019671195"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1010966019"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-1019671195" class="accordion-body collapse in">
+            <div id="namespace-1010966019" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1687100902"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1098571437"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1687100902" class="accordion-body collapse ">
+            <div id="namespace-1098571437" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-762578826"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-538438547"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-762578826" class="accordion-body collapse ">
+            <div id="namespace-538438547" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -462,7 +462,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/classes/Okta.Resource.Factor.html
+++ b/docs/classes/Okta.Resource.Factor.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-2091387594"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1928165519"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-2091387594" class="accordion-body collapse in">
+            <div id="namespace-1928165519" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-852237581"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-815731138"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-852237581" class="accordion-body collapse ">
+            <div id="namespace-815731138" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-830511449"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-50260749"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-830511449" class="accordion-body collapse ">
+            <div id="namespace-50260749" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -1035,7 +1035,7 @@ will have a result of WAITING, SUCCESS, REJECTED, or TIMEOUT.</em></p>
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/classes/Okta.Resource.Group.html
+++ b/docs/classes/Okta.Resource.Group.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-573604802"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-413647536"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-573604802" class="accordion-body collapse in">
+            <div id="namespace-413647536" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1342332373"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1045250440"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1342332373" class="accordion-body collapse ">
+            <div id="namespace-1045250440" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-504691166"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1932643964"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-504691166" class="accordion-body collapse ">
+            <div id="namespace-1932643964" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -810,7 +810,7 @@ of users</p></td>
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/classes/Okta.Resource.Role.html
+++ b/docs/classes/Okta.Resource.Role.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-65421451"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-637020453"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-65421451" class="accordion-body collapse in">
+            <div id="namespace-637020453" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-375919948"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-314311324"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-375919948" class="accordion-body collapse ">
+            <div id="namespace-314311324" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-578702425"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1710486100"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-578702425" class="accordion-body collapse ">
+            <div id="namespace-1710486100" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -656,7 +656,7 @@ of targets</p></td>
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/classes/Okta.Resource.Schema.html
+++ b/docs/classes/Okta.Resource.Schema.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-978120944"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1409547244"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-978120944" class="accordion-body collapse in">
+            <div id="namespace-1409547244" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-979055482"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1523197825"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-979055482" class="accordion-body collapse ">
+            <div id="namespace-1523197825" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-598093106"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1891876560"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-598093106" class="accordion-body collapse ">
+            <div id="namespace-1891876560" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -495,7 +495,7 @@ custom profile properties</p></td>
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/classes/Okta.Resource.Session.html
+++ b/docs/classes/Okta.Resource.Session.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1764123959"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-963366531"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-1764123959" class="accordion-body collapse in">
+            <div id="namespace-963366531" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1874181508"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-763602152"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1874181508" class="accordion-body collapse ">
+            <div id="namespace-763602152" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1662858250"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1307635451"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-1662858250" class="accordion-body collapse ">
+            <div id="namespace-1307635451" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -552,7 +552,7 @@ code.</p>
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/classes/Okta.Resource.User.html
+++ b/docs/classes/Okta.Resource.User.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-84711419"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-437251747"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-84711419" class="accordion-body collapse in">
+            <div id="namespace-437251747" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-890270218"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-328940365"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-890270218" class="accordion-body collapse ">
+            <div id="namespace-328940365" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1293014790"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1432314773"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-1293014790" class="accordion-body collapse ">
+            <div id="namespace-1432314773" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -1184,7 +1184,7 @@ credential</em></p>
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Client.html
+++ b/docs/files/Client.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-700934335"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1952323690"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-700934335" class="accordion-body collapse in">
+            <div id="namespace-1952323690" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-14838553"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1250922095"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-14838553" class="accordion-body collapse ">
+            <div id="namespace-1250922095" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1717656796"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-466429557"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-1717656796" class="accordion-body collapse ">
+            <div id="namespace-466429557" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Client.php.txt
+++ b/docs/files/Client.php.txt
@@ -46,21 +46,29 @@ class Client {
      *
      * @param string $org       Your organization's subdomain (tenant)
      * @param string $key       Your Okta API key
-     * @param array  $headers   Array of headers in header_name => value format
-     * @param bool   $bootstrap If true, bootstrap Okta resource properties
+     * @param array  $config    Array of Client config key/values
      */
-    public function __construct($org, $key, array $headers = [], $bootstrap = true) {
+    public function __construct($org, $key, array $config = []) {
+
+        $config = array_merge([
+            'apiVersion' => 'v1',
+            'bootstrap'  => true,
+            'headers'    => [],
+            'preview'    => false
+        ], $config);
+
+        $domain = $config['preview'] ? 'oktapreview.com' : 'okta.com';
 
         $this->client = new GuzzleClient ([
-            'base_uri'   => 'https://' . $org . '.okta.com/api/v1/',
+            'base_uri'   => 'https://' . $org . '.' . $domain . '/api/' . $config['apiVersion'] . '/',
             'exceptions' => false,
             'headers'    => array_merge([
                 'Authorization' => 'SSWS ' . $key,
                 'Content-Type'  => 'application/json'
-            ], $headers)
+            ], $config['headers'])
         ]);
 
-        if ($bootstrap) $this->bootstrap();
+        if ($config['bootstrap']) $this->bootstrap();
 
     }
 

--- a/docs/files/Exception.html
+++ b/docs/files/Exception.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-470680493"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1060121691"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-470680493" class="accordion-body collapse in">
+            <div id="namespace-1060121691" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1490917077"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-433763413"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1490917077" class="accordion-body collapse ">
+            <div id="namespace-433763413" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-872267375"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1513897753"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-872267375" class="accordion-body collapse ">
+            <div id="namespace-1513897753" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Request.html
+++ b/docs/files/Request.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-494046446"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1320100241"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-494046446" class="accordion-body collapse in">
+            <div id="namespace-1320100241" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-299427531"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1506959307"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-299427531" class="accordion-body collapse ">
+            <div id="namespace-1506959307" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-539462984"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1003398997"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-539462984" class="accordion-body collapse ">
+            <div id="namespace-1003398997" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Resource.App.html
+++ b/docs/files/Resource.App.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-2016766479"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-913164192"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-2016766479" class="accordion-body collapse in">
+            <div id="namespace-913164192" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1724629174"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-51526435"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1724629174" class="accordion-body collapse ">
+            <div id="namespace-51526435" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-427074786"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1073866242"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-427074786" class="accordion-body collapse ">
+            <div id="namespace-1073866242" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Resource.Authentication.html
+++ b/docs/files/Resource.Authentication.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-274817626"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-960779247"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-274817626" class="accordion-body collapse in">
+            <div id="namespace-960779247" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1944123420"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1982880920"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1944123420" class="accordion-body collapse ">
+            <div id="namespace-1982880920" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1739433988"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-853778270"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-1739433988" class="accordion-body collapse ">
+            <div id="namespace-853778270" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Resource.Base.html
+++ b/docs/files/Resource.Base.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1460960728"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1940335482"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-1460960728" class="accordion-body collapse in">
+            <div id="namespace-1940335482" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1046432749"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1548112952"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1046432749" class="accordion-body collapse ">
+            <div id="namespace-1548112952" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-160347820"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1432671284"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-160347820" class="accordion-body collapse ">
+            <div id="namespace-1432671284" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Resource.Event.html
+++ b/docs/files/Resource.Event.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1003075519"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1546103132"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-1003075519" class="accordion-body collapse in">
+            <div id="namespace-1546103132" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-2071850614"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-974404840"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-2071850614" class="accordion-body collapse ">
+            <div id="namespace-974404840" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1589023766"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-488204807"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-1589023766" class="accordion-body collapse ">
+            <div id="namespace-488204807" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Resource.Factor.html
+++ b/docs/files/Resource.Factor.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1353873523"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-683343578"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-1353873523" class="accordion-body collapse in">
+            <div id="namespace-683343578" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1528834933"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1906477469"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1528834933" class="accordion-body collapse ">
+            <div id="namespace-1906477469" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-118030935"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-923475097"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-118030935" class="accordion-body collapse ">
+            <div id="namespace-923475097" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Resource.Group.html
+++ b/docs/files/Resource.Group.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-688126942"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1518769994"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-688126942" class="accordion-body collapse in">
+            <div id="namespace-1518769994" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1092876318"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-487939753"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1092876318" class="accordion-body collapse ">
+            <div id="namespace-487939753" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1739705246"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-139651009"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-1739705246" class="accordion-body collapse ">
+            <div id="namespace-139651009" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Resource.Role.html
+++ b/docs/files/Resource.Role.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-846056339"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1048793529"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-846056339" class="accordion-body collapse in">
+            <div id="namespace-1048793529" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-537946139"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-765695901"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-537946139" class="accordion-body collapse ">
+            <div id="namespace-765695901" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-364846669"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1258963728"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-364846669" class="accordion-body collapse ">
+            <div id="namespace-1258963728" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Resource.Schema.html
+++ b/docs/files/Resource.Schema.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1546477131"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1372909175"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-1546477131" class="accordion-body collapse in">
+            <div id="namespace-1372909175" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-369252566"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1236664881"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-369252566" class="accordion-body collapse ">
+            <div id="namespace-1236664881" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1855503281"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1824415098"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-1855503281" class="accordion-body collapse ">
+            <div id="namespace-1824415098" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Resource.Session.html
+++ b/docs/files/Resource.Session.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1997606845"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-807371334"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-1997606845" class="accordion-body collapse in">
+            <div id="namespace-807371334" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1731575048"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-2043482406"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1731575048" class="accordion-body collapse ">
+            <div id="namespace-2043482406" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-906244612"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1380884491"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-906244612" class="accordion-body collapse ">
+            <div id="namespace-1380884491" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/files/Resource.User.html
+++ b/docs/files/Resource.User.html
@@ -144,28 +144,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-115168049"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-884991232"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-115168049" class="accordion-body collapse in">
+            <div id="namespace-884991232" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1802951567"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-403581294"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1802951567" class="accordion-body collapse ">
+            <div id="namespace-403581294" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1138059360"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1657748425"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-1138059360" class="accordion-body collapse ">
+            <div id="namespace-1657748425" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -297,7 +297,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/graphs/class.html
+++ b/docs/graphs/class.html
@@ -161,7 +161,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -96,28 +96,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1050539576"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1224401186"></a>
                                 <a href="namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-1050539576" class="accordion-body collapse in">
+            <div id="namespace-1224401186" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-167902408"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1799135475"></a>
                                 <a href="namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-167902408" class="accordion-body collapse ">
+            <div id="namespace-1799135475" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-2070159148"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-371742515"></a>
                                 <a href="namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-2070159148" class="accordion-body collapse ">
+            <div id="namespace-371742515" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -231,7 +231,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/namespaces/Okta.Resource.html
+++ b/docs/namespaces/Okta.Resource.html
@@ -96,28 +96,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-120178022"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1702135248"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-120178022" class="accordion-body collapse in">
+            <div id="namespace-1702135248" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1298545159"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-991293641"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1298545159" class="accordion-body collapse ">
+            <div id="namespace-991293641" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-52300309"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1747949677"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-52300309" class="accordion-body collapse ">
+            <div id="namespace-1747949677" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -272,7 +272,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/namespaces/Okta.html
+++ b/docs/namespaces/Okta.html
@@ -96,28 +96,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-1265271840"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-53492851"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-1265271840" class="accordion-body collapse in">
+            <div id="namespace-53492851" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1350385034"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1767045134"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-1350385034" class="accordion-body collapse ">
+            <div id="namespace-1767045134" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-2070993298"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1091241600"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-2070993298" class="accordion-body collapse ">
+            <div id="namespace-1091241600" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -248,7 +248,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/namespaces/default.html
+++ b/docs/namespaces/default.html
@@ -96,28 +96,28 @@
                                 <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-684857919"></a>
+                                    <a class="accordion-toggle " data-toggle="collapse" data-target="#namespace-345091437"></a>
                                 <a href="../namespaces/default.html" style="margin-left: 30px; padding-left: 0">\</a>
             </div>
-            <div id="namespace-684857919" class="accordion-body collapse in">
+            <div id="namespace-345091437" class="accordion-body collapse in">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-269389250"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-1909511053"></a>
                                 <a href="../namespaces/Okta.html" style="margin-left: 30px; padding-left: 0">Okta</a>
             </div>
-            <div id="namespace-269389250" class="accordion-body collapse ">
+            <div id="namespace-1909511053" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                                                     <div class="accordion" style="margin-bottom: 0">
         <div class="accordion-group">
             <div class="accordion-heading">
-                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-103123122"></a>
+                                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-target="#namespace-251079418"></a>
                                 <a href="../namespaces/Okta.Resource.html" style="margin-left: 30px; padding-left: 0">Resource</a>
             </div>
-            <div id="namespace-103123122" class="accordion-body collapse ">
+            <div id="namespace-251079418" class="accordion-body collapse ">
                 <div class="accordion-inner">
 
                     
@@ -231,7 +231,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/reports/deprecated.html
+++ b/docs/reports/deprecated.html
@@ -151,7 +151,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/reports/errors.html
+++ b/docs/reports/errors.html
@@ -498,7 +498,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/docs/reports/markers.html
+++ b/docs/reports/markers.html
@@ -150,7 +150,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on April 4th, 2016 at 14:03.
+                    on April 12th, 2016 at 12:43.
                 </section>
             </section>
         </section>

--- a/src/Client.php
+++ b/src/Client.php
@@ -46,21 +46,29 @@ class Client {
      *
      * @param string $org       Your organization's subdomain (tenant)
      * @param string $key       Your Okta API key
-     * @param array  $headers   Array of headers in header_name => value format
-     * @param bool   $bootstrap If true, bootstrap Okta resource properties
+     * @param array  $config    Array of Client config key/values
      */
-    public function __construct($org, $key, array $headers = [], $bootstrap = true) {
+    public function __construct($org, $key, array $config = []) {
+
+        $config = array_merge([
+            'apiVersion' => 'v1',
+            'bootstrap'  => true,
+            'headers'    => [],
+            'preview'    => false
+        ], $config);
+
+        $domain = $config['preview'] ? 'oktapreview.com' : 'okta.com';
 
         $this->client = new GuzzleClient ([
-            'base_uri'   => 'https://' . $org . '.okta.com/api/v1/',
+            'base_uri'   => 'https://' . $org . '.' . $domain . '/api/' . $config['apiVersion'] . '/',
             'exceptions' => false,
             'headers'    => array_merge([
                 'Authorization' => 'SSWS ' . $key,
                 'Content-Type'  => 'application/json'
-            ], $headers)
+            ], $config['headers'])
         ]);
 
-        if ($bootstrap) $this->bootstrap();
+        if ($config['bootstrap']) $this->bootstrap();
 
     }
 

--- a/tests/OktaClientTest.php
+++ b/tests/OktaClientTest.php
@@ -45,7 +45,7 @@ class OktaClientTest extends PHPUnit_Framework_TestCase
     }
 
     public function testNonBootstrappedResourcePropertiesAreNull() {
-        $okta = new Okta\Client('test', 'not_a_real_key', [], false);
+        $okta = new Okta\Client('test', 'not_a_real_key', ['bootstrap' => false]);
         $this->assertNull($okta->app);
         $this->assertNull($okta->auth);
         $this->assertNull($okta->event);


### PR DESCRIPTION
  - **[BREAKING]** Modified Okta\Client constructor to accept an array of config options for setting API version, headers and bootstrap/preview booleans (see below)
  - Updated tests to accommodate these changes

-----

If you were previously passing in an array of headers like so:

```php
$okta = new Okta\Client('org', 'key', [
    'Some-Header'    => 'Some Value',
    'Another-Header' => 'Another Value'
];
```

you will need to update to this format:

```php
$okta = new Okta\Client('org', 'key', [
    'headers' => [
        'Some-Header'    => 'Some Value',
        'Another-Header' => 'Another Value'
    ]
];
```