### PR TITLE
Fix answerRecoveryQuestion()

### DIFF
--- a/src/Resource/Authentication.php
+++ b/src/Resource/Authentication.php
@@ -316,7 +316,10 @@ class Authentication extends Base
     {
         $request = $this->request->post('authn/recovery/answer');
 
-        $request->data(['answer' => $answer]);
+        $request->data([
+            'stateToken' => $stateToken,
+            'answer'     => $answer
+        ]);
 
         return $request->send();
     }


### PR DESCRIPTION
Fixed Authentication::answerRecoveryQuestion() method failing to send the stateToken with the request.